### PR TITLE
Added new ActionRule to allow Actions to be called on the response object

### DIFF
--- a/src/RestFluencing.Core/Assertion/Rules/ActionRule.cs
+++ b/src/RestFluencing.Core/Assertion/Rules/ActionRule.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RestFluencing.Assertion.Rules
+{
+    /// <summary>
+    /// Rules that allows an Action to be called on the response object.
+    /// This type of rule does not support asserts, but will fail if the response cannot be deserialised or if the Action throws an exception.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class ActionRule<T> : AssertionRule
+    {
+        private readonly Action<T> _action;
+        private readonly Type _assertType;
+
+        public ActionRule(Action<T> action)
+            : base("Action")
+        {
+            _action = action;
+            _assertType = typeof(T);
+        }
+
+        /// <summary>
+        /// Calls the Action on the response object.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public override IEnumerable<AssertionResult> Assert(AssertionContext context)
+        {
+            if (string.IsNullOrEmpty(context.Response.Content))
+            {
+                yield return new AssertionResult(this, $"Response was blank");
+                yield break;
+            }
+
+            var obj = default(T);
+            Exception error = null;
+            try
+            {
+                obj = context.ResponseDeserialiser.GetResponse<T>(context);
+            }
+            catch (Exception ex)
+            {
+                error = ex;
+            }
+
+            if (obj == null)
+                yield return new AssertionResult(this, $"Failed to deserialise response to {_assertType}");
+
+            if (error != null)
+                yield return new AssertionResult(this, error.Message);
+
+            if (obj == null || error != null)
+                yield break;
+
+            AssertionResult result = null;
+
+            try
+            {
+                _action(obj);
+            }
+            catch (Exception ex)
+            {
+                result = new AssertionResult(this, ex.ToString());
+            }
+
+            if (result != null)
+                yield return result;
+        }
+    }
+}

--- a/src/restfluencing.Core/Assertion/RestResponseAssertionSetupExtensions.cs
+++ b/src/restfluencing.Core/Assertion/RestResponseAssertionSetupExtensions.cs
@@ -83,15 +83,32 @@ namespace RestFluencing.Assertion
 			return response;
 		}
 
-		/// <summary>
-		/// Asserts that the response content contains the expected value based on the type provided
-		/// </summary>
-		/// <typeparam name="T">Expected response Type</typeparam>
-		/// <param name="response"></param>
-		/// <param name="expression">Expression to validate</param>
-		/// <param name="errorReason">Explicit error message</param>
-		/// <returns></returns>
-		public static RestResponse Returns<T>(this RestResponse response, Expression<Func<T, bool>> expression, string errorReason)
+        /// <summary>
+        /// Allows an Action to be called on the response object.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="response"></param>
+        /// <param name="action">Action to call on the response object.</param>
+        /// <returns></returns>
+        public static RestResponse Action<T>(this RestResponse response, Action<T> action)
+        {
+            if (response == null)
+            {
+                throw new ArgumentNullException(nameof(response));
+            }
+            response.AddRule(new ActionRule<T>(action));
+            return response;
+        }
+
+        /// <summary>
+        /// Asserts that the response content contains the expected value based on the type provided
+        /// </summary>
+        /// <typeparam name="T">Expected response Type</typeparam>
+        /// <param name="response"></param>
+        /// <param name="expression">Expression to validate</param>
+        /// <param name="errorReason">Explicit error message</param>
+        /// <returns></returns>
+        public static RestResponse Returns<T>(this RestResponse response, Expression<Func<T, bool>> expression, string errorReason)
 		{
 			if (response == null)
 			{

--- a/src/restfluencing.Core/restfluencing.Core.csproj
+++ b/src/restfluencing.Core/restfluencing.Core.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Assertion\Rules\AssertFailureRule.cs" />
     <Compile Include="Assertion\Rules\BlankResponseAssertionRule.cs" />
     <Compile Include="Assertion\Rules\DynamicExpressionAssertionRule.cs" />
+    <Compile Include="Assertion\Rules\ActionRule.cs" />
     <Compile Include="Assertion\Rules\ExpressionAssertionRule.cs" />
     <Compile Include="Assertion\IAssertion.cs" />
     <Compile Include="Assertion\Rules\AssertionRule.cs" />

--- a/tests/RestFluencing.Tests/ActionRuleTests.cs
+++ b/tests/RestFluencing.Tests/ActionRuleTests.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RestFluencing;
+using RestFluencing.Assertion;
+using RestFluencing.Tests;
+using RestFluencing.Tests.Clients;
+using RestFluencing.Tests.Models;
+
+namespace RestFluencing.Tests
+{
+    [TestClass]
+    public class ActionRuleTests
+    {
+        private RestConfiguration _configuration = null;
+        private TestApiFactory _factory = null;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            // Setup Defaults
+            var restDefaults = RestConfiguration.JsonDefault();
+            restDefaults.WithBaseUrl("http://test.starnow.local/");
+            _configuration = restDefaults;
+
+            // Setup Factory
+            var factory = Factories.Default();
+            restDefaults.ClientFactory = factory;
+            _factory = factory as TestApiFactory;
+        }
+
+        [TestMethod]
+        public void Action_ShouldBePassedResponse()
+        {
+            string name = null;
+
+            Rest.Get("/product/apple", _configuration)
+                .Response()
+                .Action<Product>(p => name = p.Name)
+                .Execute()
+                .ShouldPass();
+
+            Assert.AreEqual("Apple", name);
+        }
+    }
+}

--- a/tests/restfluencing.Tests/restfluencing.Tests.csproj
+++ b/tests/restfluencing.Tests/restfluencing.Tests.csproj
@@ -77,6 +77,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="ActionRuleTests.cs" />
     <Compile Include="Clients\TestApiClient.cs" />
     <Compile Include="Clients\TestApiFactory.cs" />
     <Compile Include="ExpressionAssertionRule.cs" />


### PR DESCRIPTION
This allows an Action<T> to be called on the response (without any asserts). Typically this would let you access properties from the response to be used to make subsequent API calls.