### PR TITLE
Response now includes all headers

### DIFF
--- a/src/restfluencing.Core/Client/HttpClientWrapper/HttpClient.cs
+++ b/src/restfluencing.Core/Client/HttpClientWrapper/HttpClient.cs
@@ -61,7 +61,7 @@ namespace RestFluencing.Client.HttpApiClient
 				{
 					result.Status = (int) response.StatusCode;
 					result.StatusCode = (HttpStatusCode) (int) response.StatusCode;
-					result.Headers = CreateHeaders(response.Content.Headers);
+					result.Headers = CreateHeaders(response.Headers);
 					result.Content = response.Content.ReadAsStringAsync().GetSyncResult();
 					return result;
 				}
@@ -75,13 +75,13 @@ namespace RestFluencing.Client.HttpApiClient
 		{
 		}
 
-		private IDictionary<string, IEnumerable<string>> CreateHeaders(HttpContentHeaders responseHeaders)
+		private IDictionary<string, IEnumerable<string>> CreateHeaders(HttpHeaders responseHeaders)
 		{
 			var result = new Dictionary<string, IEnumerable<string>>();
 			
 			foreach (var h in responseHeaders)
 			{
-				result.Add(h.Key,h.Value);
+				result.Add(h.Key, h.Value);
 			}
 
 			return result;


### PR DESCRIPTION
Hi,

We are trying to use RestFluencing to check for response headers, like "ETag", but when we assert with HasHeader() it only 'sees' some headers. For example, the "ETag" header returned from GET https://api.github.com/users/defunkt is not seen, and .HasHeader("ETag") will fail.

This seems to come down to the fact that IApiClientResponse is only populated with response.Content.Headers (instead of response.Headers). HttpContentHeaders will only include a subset of all headers: https://docs.microsoft.com/en-us/dotnet/api/system.net.http.headers.httpcontentheaders?view=netframework-4.7.2

This PR will make all headers available to asserts.

Adam
